### PR TITLE
breaking changes: fix bug that confusing template literal by go-config

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,7 +48,9 @@ func NewConfig(r io.Reader) (Config, error) {
 		return c, errors.Wrap(err, "cannot read config reader")
 	}
 
-	err = config.LoadWithEnvBytes(&c, bs)
+	loader := config.New()
+	loader.Delims("%%", "%%")
+	err = loader.LoadWithEnvBytes(&c, bs)
 	if err != nil {
 		return c, errors.Wrap(err, "cannot unmarshal config")
 	}


### PR DESCRIPTION
* from the changed config loader to kayac/go-config, it's can read parameters of config from environment variables.
* but already used go-template delimiters on the title value
* confused title values and go-config values
* because changing go-config delimiters that `%%`
  * Ex: ```%% must_env `GITHUB_TOKEN` %%```