### PR TITLE
can specify base branch names of merged pull requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,10 +27,11 @@ type call struct {
 }
 
 type Repo struct {
-	Owner string `yaml:"owner"`
-	Repo  string `yaml:"repo"`
-	Head  string `yaml:"head"`
-	Base  string `yaml:"base"`
+	Owner            string   `yaml:"owner"`
+	Repo             string   `yaml:"repo"`
+	Head             string   `yaml:"head"`
+	LogContainsBases []string `yaml:"log_contains_bases"`
+	Base             string   `yaml:"base"`
 }
 
 func (r Repo) JoinedHead() string {
@@ -38,6 +39,16 @@ func (r Repo) JoinedHead() string {
 		return r.Head
 	}
 	return strings.Join([]string{r.Owner, r.Head}, ":")
+}
+
+func (r Repo) ContainsBase(base string) bool {
+	bases := append(r.LogContainsBases, r.Head)
+	for _, _base := range bases {
+		if _base == base {
+			return true
+		}
+	}
+	return false
 }
 
 func NewConfig(r io.Reader) (Config, error) {

--- a/fetcher.go
+++ b/fetcher.go
@@ -190,7 +190,7 @@ func (f *fetcher) MergedPullRequests(ctx context.Context) (PullRequests, error) 
 		if !pr.Fetched {
 			continue
 		}
-		if pr.Base != f.Repo.Head {
+		if !f.Repo.ContainsBase(pr.Base) {
 			continue
 		}
 		freezedPRs = append(freezedPRs, *pr)


### PR DESCRIPTION
* In the case of pull request checked out "release candidate" branch from the develop to master, on run the `release-request` but not listed pull requests.
* This problem occurred because that filter on list pull requests by branch name from `head` config.
* So I added `log_contains_bases` option. This option adds to the names in the filter uses.